### PR TITLE
feat: add authorization detail view

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -47,7 +47,21 @@
       error_authorizations = err.message;
     }
   });
-  
+
+  let selectedAuthorization = null;
+  let error_authorization_details = '';
+
+  async function loadAuthorizationDetails(id) {
+    selectedAuthorization = null;
+    error_authorization_details = '';
+    try {
+      const res = await fetch(`${API_ENDPOINTS.authorizations}/${id}`);
+      if (!res.ok) throw new Error(await res.text());
+      selectedAuthorization = await res.json();
+    } catch (err) {
+      error_authorization_details = err.message;
+    }
+  }
 </script>
 
 {#if error_students}
@@ -81,7 +95,20 @@
   <h3>Autorizaciones</h3>
   <ul>
     {#each authorizations as a}
-      <li>{a.title} ({a.id})</li>
+      <li>
+        {a.title} ({a.id})
+        <button on:click={() => loadAuthorizationDetails(a.id)}>
+          Ver detalles
+        </button>
+      </li>
     {/each}
   </ul>
+  {#if error_authorization_details}
+    <p class="error">{error_authorization_details}</p>
+  {:else if selectedAuthorization}
+    <div class="authorization-details">
+      <h4>Detalles de la autorización</h4>
+      <pre>{JSON.stringify(selectedAuthorization, null, 2)}</pre>
+    </div>
+  {/if}
 {/if}


### PR DESCRIPTION
## Summary
- add button to fetch and display authorization details

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bde91952e08329887c2df2cfbae1d9