### PR TITLE
docs: document dev api base url setup

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=https://template-api-render.onrender.com/api

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 This template should help get you started developing with Svelte in Vite.
 
+## Running locally
+
+The app expects an API base URL provided through the `VITE_API_BASE_URL` environment variable.
+A default value is included in `.env.development` so that the dev server uses the same
+API endpoint as production. Update this file if you need to point to a different backend.
+
 ## Recommended IDE Setup
 
 [VS Code](https://code.visualstudio.com/) + [Svelte](https://marketplace.visualstudio.com/items?itemName=svelte.svelte-vscode).


### PR DESCRIPTION
## Summary
- document the required `VITE_API_BASE_URL` env var for running locally
- add `.env.development` to default to the production API

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bdeafe89e88329a0cd736bc85d23c7